### PR TITLE
Implement multi-scale loss for mitigating long-term drift

### DIFF
--- a/configs/BlackBird/motion_body_rot.conf
+++ b/configs/BlackBird/motion_body_rot.conf
@@ -26,7 +26,7 @@ train:
    cov_weight: 1e-4
    propcov:False
    covaug:False
-   obsersup: False
+   obsersup: True
    loss: Huber_loss005
    rotloss: Huber_loss005
     

--- a/datasets/BlackBirddataset.py
+++ b/datasets/BlackBirddataset.py
@@ -25,7 +25,7 @@ class BlackBird(Sequence):
         rot_path=None,
         rot_type=None,
         gravity=9.81007, 
-        remove_g=False,
+        remove_g=True,
         **kwargs
     ):
         super(BlackBird, self).__init__()

--- a/model/losses.py
+++ b/model/losses.py
@@ -29,7 +29,7 @@ def motion_loss_(fc, pred, targ):
     loss = fc(dist)
     return loss, dist
 
-def multi_scale_motion_loss_(loss_fc, rot, net_vel, labe, overlap=False):
+def multi_scale_motion_loss_(loss_fc, rot, net_vel, label, overlap=False):
     assert rot.shape[1] == net_vel.shape[1] + 1
     omegas = rot[:, :-1, :].Inv() @ rot[:, 1:, :]
 


### PR DESCRIPTION
Current multi-scale loss only works for relative velocity supervision with gravity compensation on inputs. The multi-scale label is computed via its relation with single-scale label. 